### PR TITLE
supports HTTPS API endpoints

### DIFF
--- a/lib/librarian/chef/source/site.rb
+++ b/lib/librarian/chef/source/site.rb
@@ -336,7 +336,9 @@ module Librarian
           end
 
           def http(uri)
-            environment.net_http_class(uri.host).new(uri.host, uri.port)
+            net_http = environment.net_http_class(uri.host).new(uri.host, uri.port)
+            net_http.use_ssl = true if uri.scheme == 'https'
+            net_http
           end
 
           def http_get(uri)


### PR DESCRIPTION
This allows users to add an HTTPS source in their Cheffile.

e.g., 

```
site 'https://cookbooks.opscode.com/api/v1'
```
