### PR TITLE
Replace possibly buggy FileUtils.mv with a two step solution

### DIFF
--- a/lib/librarian/chef/source/site.rb
+++ b/lib/librarian/chef/source/site.rb
@@ -309,7 +309,8 @@ module Librarian
             subtemps.size > 1 and raise "The package archive has too many children!"
             subtemp = subtemps.first
             debug { "Moving #{relative_path_to(subtemp)} to #{relative_path_to(path)}" }
-            FileUtils.mv(subtemp, path)
+            FileUtils.cp_r(subtemp, path)
+            FileUtils.rm_rf(subtemp)
           ensure
             temp.rmtree if temp && temp.exist?
           end


### PR DESCRIPTION
On Windows 7/8 64bit, when using librarian-chef both standalone and trough vagrant, the `FileUtils.mv` operation fails with `Errno::EACCES` (permission denied). I suspect it could be a ruby bug, in any case it could be easily worked around.
