### PR TITLE
Fixes to support Supermarket

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ depends will go here.
 
 Here's an example `Cheffile`:
 
-    site "http://community.opscode.com/api/v1"
+    site "https://supermarket.getchef.com/api/v1"
 
     cookbook "ntp"
     cookbook "timezone", "0.0.1"
@@ -58,7 +58,7 @@ Here's how it works:
 
 We start off by declaring the *default source* for this `Cheffile`.
 
-    site "http://community.opscode.com/api/v1"
+    site "https://supermarket.getchef.com/api/v1"
 
 This default source in this example is the Opscode Community Site API. This is
 most likely what you will want for your default source. However, you can
@@ -161,7 +161,7 @@ default source.
 Add dependencies and their sources to the `Cheffile`:
 
     $ cat Cheffile
-        site 'http://community.opscode.com/api/v1'
+        site 'https://supermarket.getchef.com/api/v1'
         cookbook 'ntp'
         cookbook 'timezone', '0.0.1'
         cookbook 'rvm',
@@ -211,7 +211,7 @@ Inspect the details of specific resolved dependencies with:
 Update your `Cheffile` with new/changed/removed constraints/sources/dependencies:
 
     $ cat Cheffile
-        site 'http://community.opscode.com/api/v1'
+        site 'https://supermarket.getchef.com/api/v1'
         cookbook 'ntp'
         cookbook 'timezone', '0.0.1'
         cookbook 'rvm',

--- a/lib/librarian/chef/source/site.rb
+++ b/lib/librarian/chef/source/site.rb
@@ -349,7 +349,6 @@ module Librarian
               debug { "Performing http-get for #{uri}" }
               http = http(uri)
               http.use_ssl = uri.scheme == 'https'
-              http.verify_mode = OpenSSL::SSL::VERIFY_NONE
               request = Net::HTTP::Get.new(uri.path)
               response = http.start{|http| http.request(request)}
 

--- a/lib/librarian/chef/source/site.rb
+++ b/lib/librarian/chef/source/site.rb
@@ -348,6 +348,8 @@ module Librarian
             loop do
               debug { "Performing http-get for #{uri}" }
               http = http(uri)
+              http.use_ssl = uri.scheme == 'https'
+              http.verify_mode = OpenSSL::SSL::VERIFY_NONE
               request = Net::HTTP::Get.new(uri.path)
               response = http.start{|http| http.request(request)}
 

--- a/lib/librarian/chef/templates/Cheffile
+++ b/lib/librarian/chef/templates/Cheffile
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 #^syntax detection
 
-site 'http://community.opscode.com/api/v1'
+site 'https://supermarket.getchef.com/api/v1'
 
 # cookbook 'chef-client'
 

--- a/librarian-chef.gemspec
+++ b/librarian-chef.gemspec
@@ -23,6 +23,6 @@ Gem::Specification.new do |gem|
   gem.add_dependency "minitar", ">= 0.5.2"
 
   gem.add_development_dependency "rake"
-  gem.add_development_dependency "rspec"
+  gem.add_development_dependency "rspec", "~> 3.0"
   gem.add_development_dependency "webmock"
 end

--- a/spec/functional/chef/source/site_spec.rb
+++ b/spec/functional/chef/source/site_spec.rb
@@ -118,7 +118,7 @@ module Librarian
           describe "#manifests" do
             it "gives a list of all manifests" do
               manifests = source.manifests("sample")
-              manifests.should have(1).item
+              expect(manifests.size).to eq(1)
               manifest = manifests.first
               manifest.source.should be source
               manifest.version.should == Manifest::Version.new("0.6.5")

--- a/spec/integration/chef/source/git_spec.rb
+++ b/spec/integration/chef/source/git_spec.rb
@@ -145,7 +145,7 @@ module Librarian
             end
           end
 
-          context "resolving and and separately installing" do
+          context "resolving and separately installing" do
             let(:repo_path) { tmp_path.join("repo/resolve-install") }
             before do
               repo_path.rmtree if repo_path.exist?
@@ -438,7 +438,7 @@ module Librarian
               metadata_file.should exist #sanity
               old_code_file.should exist #sanity
 
-              new_code_file.should exist # the assertion
+              new_code_file.should_not exist # the assertion
             end
           end
         end


### PR DESCRIPTION
- Explicitly enable ssl.
- Examples changed to point to supermarket instead of the old community site.
- Some tests fixed.
  - Require RSpec  `~> 3.0` (recommended due to the `undefined method have for ...` issue).
