### PR TITLE
Ignore PaxHeader subfolder from tar archives

### DIFF
--- a/lib/librarian/chef/source/site.rb
+++ b/lib/librarian/chef/source/site.rb
@@ -305,7 +305,7 @@ module Librarian
             # can include the subfolder `pax_global_header`, which is ignored.
             subtemps = temp.children
             subtemps.empty? and raise "The package archive was empty!"
-            subtemps.delete_if{|pth| pth.to_s[/pax_global_header/]}
+            subtemps.delete_if{|pth| pth.to_s[/pax_global_header|PaxHeader/]}
             subtemps.size > 1 and raise "The package archive has too many children!"
             subtemp = subtemps.first
             debug { "Moving #{relative_path_to(subtemp)} to #{relative_path_to(path)}" }


### PR DESCRIPTION
Some tar archives from community site can include a subfolder named _PaxHeader_, which will cause the following error:

```
librarian/chef/source/site.rb:309:in `unpack_package!': The package archive has too many children! (RuntimeError)
```
## How to reproduce

Use the following _Cheffile_ to download a cookbook with this header:

``` ruby
#!/usr/bin/env ruby
#^syntax detection

site 'https://supermarket.getchef.com/api/v1'

cookbook 'zookeeper'
```

```
$ librarian-chef update
```
## Full Exception

```
~/.rvm/gems/ruby-2.0.0-p481@chef-dev/gems/librarian-chef-0.0.4/lib/librarian/chef/source/site.rb:309:in `unpack_package!': The package archive has too many children! (RuntimeError)
        from ~/.rvm/gems/ruby-2.0.0-p481@chef-dev/gems/librarian-chef-0.0.4/lib/librarian/chef/source/site.rb:224:in `cache_version_uri_unpacked!'
        from ~/.rvm/gems/ruby-2.0.0-p481@chef-dev/gems/librarian-chef-0.0.4/lib/librarian/chef/source/site.rb:93:in `block in version_uri_manifest'
        from ~/.rvm/gems/ruby-2.0.0-p481@chef-dev/gems/librarian-chef-0.0.4/lib/librarian/chef/source/site.rb:381:in `memo'
        from ~/.rvm/gems/ruby-2.0.0-p481@chef-dev/gems/librarian-chef-0.0.4/lib/librarian/chef/source/site.rb:92:in `version_uri_manifest'
        from ~/.rvm/gems/ruby-2.0.0-p481@chef-dev/gems/librarian-chef-0.0.4/lib/librarian/chef/source/site.rb:88:in `version_manifest'
        from ~/.rvm/gems/ruby-2.0.0-p481@chef-dev/gems/librarian-chef-0.0.4/lib/librarian/chef/source/site.rb:54:in `version_dependencies'
        from ~/.rvm/gems/ruby-2.0.0-p481@chef-dev/gems/librarian-chef-0.0.4/lib/librarian/chef/source/site.rb:462:in `fetch_dependencies'
        from ~/.rvm/gems/ruby-2.0.0-p481@chef-dev/gems/librarian-0.1.2/lib/librarian/manifest.rb:125:in `fetch_dependencies!'
        from ~/.rvm/gems/ruby-2.0.0-p481@chef-dev/gems/librarian-0.1.2/lib/librarian/manifest.rb:117:in `fetched_dependencies'
        from ~/.rvm/gems/ruby-2.0.0-p481@chef-dev/gems/librarian-0.1.2/lib/librarian/manifest.rb:81:in `dependencies'
        from ~/.rvm/gems/ruby-2.0.0-p481@chef-dev/gems/librarian-0.1.2/lib/librarian/resolver/implementation.rb:117:in `block in check_manifest_for_cycles'
        from ~/.rvm/gems/ruby-2.0.0-p481@chef-dev/gems/librarian-0.1.2/lib/librarian/resolver/implementation.rb:117:in `each'
        from ~/.rvm/gems/ruby-2.0.0-p481@chef-dev/gems/librarian-0.1.2/lib/librarian/resolver/implementation.rb:117:in `map'
        from ~/.rvm/gems/ruby-2.0.0-p481@chef-dev/gems/librarian-0.1.2/lib/librarian/resolver/implementation.rb:117:in `check_manifest_for_cycles'
        from ~/.rvm/gems/ruby-2.0.0-p481@chef-dev/gems/librarian-0.1.2/lib/librarian/resolver/implementation.rb:64:in `block in recursive_resolve'
        from ~/.rvm/gems/ruby-2.0.0-p481@chef-dev/gems/librarian-0.1.2/lib/librarian/resolver/implementation.rb:154:in `block (3 levels) in resolving_dependency_map_find_manifests'
        from ~/.rvm/gems/ruby-2.0.0-p481@chef-dev/gems/librarian-0.1.2/lib/librarian/resolver/implementation.rb:187:in `block in scope_checking_manifest'
        from ~/.rvm/gems/ruby-2.0.0-p481@chef-dev/gems/librarian-0.1.2/lib/librarian/resolver/implementation.rb:223:in `scope'
        from ~/.rvm/gems/ruby-2.0.0-p481@chef-dev/gems/librarian-0.1.2/lib/librarian/resolver/implementation.rb:186:in `scope_checking_manifest'
        from ~/.rvm/gems/ruby-2.0.0-p481@chef-dev/gems/librarian-0.1.2/lib/librarian/resolver/implementation.rb:153:in `block (2 levels) in resolving_dependency_map_find_manifests'
        from ~/.rvm/gems/ruby-2.0.0-p481@chef-dev/gems/librarian-0.1.2/lib/librarian/resolver/implementation.rb:211:in `block in map_find'
        from ~/.rvm/gems/ruby-2.0.0-p481@chef-dev/gems/librarian-0.1.2/lib/librarian/resolver/implementation.rb:210:in `each'
        from ~/.rvm/gems/ruby-2.0.0-p481@chef-dev/gems/librarian-0.1.2/lib/librarian/resolver/implementation.rb:210:in `map_find'
        from ~/.rvm/gems/ruby-2.0.0-p481@chef-dev/gems/librarian-0.1.2/lib/librarian/resolver/implementation.rb:152:in `block in resolving_dependency_map_find_manifests'
        from ~/.rvm/gems/ruby-2.0.0-p481@chef-dev/gems/librarian-0.1.2/lib/librarian/resolver/implementation.rb:165:in `block (2 levels) in scope_resolving_dependency'
        from ~/.rvm/gems/ruby-2.0.0-p481@chef-dev/gems/librarian-0.1.2/lib/librarian/resolver/implementation.rb:179:in `block in scope_checking_manifests'
        from ~/.rvm/gems/ruby-2.0.0-p481@chef-dev/gems/librarian-0.1.2/lib/librarian/resolver/implementation.rb:223:in `scope'
        from ~/.rvm/gems/ruby-2.0.0-p481@chef-dev/gems/librarian-0.1.2/lib/librarian/resolver/implementation.rb:178:in `scope_checking_manifests'
        from ~/.rvm/gems/ruby-2.0.0-p481@chef-dev/gems/librarian-0.1.2/lib/librarian/resolver/implementation.rb:164:in `block in scope_resolving_dependency'
        from ~/.rvm/gems/ruby-2.0.0-p481@chef-dev/gems/librarian-0.1.2/lib/librarian/resolver/implementation.rb:223:in `scope'
        from ~/.rvm/gems/ruby-2.0.0-p481@chef-dev/gems/librarian-0.1.2/lib/librarian/resolver/implementation.rb:163:in `scope_resolving_dependency'
        from ~/.rvm/gems/ruby-2.0.0-p481@chef-dev/gems/librarian-0.1.2/lib/librarian/resolver/implementation.rb:151:in `resolving_dependency_map_find_manifests'
        from ~/.rvm/gems/ruby-2.0.0-p481@chef-dev/gems/librarian-0.1.2/lib/librarian/resolver/implementation.rb:62:in `recursive_resolve'
        from ~/.rvm/gems/ruby-2.0.0-p481@chef-dev/gems/librarian-0.1.2/lib/librarian/resolver/implementation.rb:70:in `block in recursive_resolve'
        from ~/.rvm/gems/ruby-2.0.0-p481@chef-dev/gems/librarian-0.1.2/lib/librarian/resolver/implementation.rb:154:in `block (3 levels) in resolving_dependency_map_find_manifests'
        from ~/.rvm/gems/ruby-2.0.0-p481@chef-dev/gems/librarian-0.1.2/lib/librarian/resolver/implementation.rb:187:in `block in scope_checking_manifest'
        from ~/.rvm/gems/ruby-2.0.0-p481@chef-dev/gems/librarian-0.1.2/lib/librarian/resolver/implementation.rb:223:in `scope'
        from ~/.rvm/gems/ruby-2.0.0-p481@chef-dev/gems/librarian-0.1.2/lib/librarian/resolver/implementation.rb:186:in `scope_checking_manifest'
        from ~/.rvm/gems/ruby-2.0.0-p481@chef-dev/gems/librarian-0.1.2/lib/librarian/resolver/implementation.rb:153:in `block (2 levels) in resolving_dependency_map_find_manifests'
        from ~/.rvm/gems/ruby-2.0.0-p481@chef-dev/gems/librarian-0.1.2/lib/librarian/resolver/implementation.rb:211:in `block in map_find'
        from ~/.rvm/gems/ruby-2.0.0-p481@chef-dev/gems/librarian-0.1.2/lib/librarian/resolver/implementation.rb:210:in `each'
        from ~/.rvm/gems/ruby-2.0.0-p481@chef-dev/gems/librarian-0.1.2/lib/librarian/resolver/implementation.rb:210:in `map_find'
        from ~/.rvm/gems/ruby-2.0.0-p481@chef-dev/gems/librarian-0.1.2/lib/librarian/resolver/implementation.rb:152:in `block in resolving_dependency_map_find_manifests'
        from ~/.rvm/gems/ruby-2.0.0-p481@chef-dev/gems/librarian-0.1.2/lib/librarian/resolver/implementation.rb:165:in `block (2 levels) in scope_resolving_dependency'
        from ~/.rvm/gems/ruby-2.0.0-p481@chef-dev/gems/librarian-0.1.2/lib/librarian/resolver/implementation.rb:179:in `block in scope_checking_manifests'
        from ~/.rvm/gems/ruby-2.0.0-p481@chef-dev/gems/librarian-0.1.2/lib/librarian/resolver/implementation.rb:223:in `scope'
        from ~/.rvm/gems/ruby-2.0.0-p481@chef-dev/gems/librarian-0.1.2/lib/librarian/resolver/implementation.rb:178:in `scope_checking_manifests'
        from ~/.rvm/gems/ruby-2.0.0-p481@chef-dev/gems/librarian-0.1.2/lib/librarian/resolver/implementation.rb:164:in `block in scope_resolving_dependency'
        from ~/.rvm/gems/ruby-2.0.0-p481@chef-dev/gems/librarian-0.1.2/lib/librarian/resolver/implementation.rb:223:in `scope'
        from ~/.rvm/gems/ruby-2.0.0-p481@chef-dev/gems/librarian-0.1.2/lib/librarian/resolver/implementation.rb:163:in `scope_resolving_dependency'
        from ~/.rvm/gems/ruby-2.0.0-p481@chef-dev/gems/librarian-0.1.2/lib/librarian/resolver/implementation.rb:151:in `resolving_dependency_map_find_manifests'
        from ~/.rvm/gems/ruby-2.0.0-p481@chef-dev/gems/librarian-0.1.2/lib/librarian/resolver/implementation.rb:62:in `recursive_resolve'
        from ~/.rvm/gems/ruby-2.0.0-p481@chef-dev/gems/librarian-0.1.2/lib/librarian/resolver/implementation.rb:50:in `resolve'
        from ~/.rvm/gems/ruby-2.0.0-p481@chef-dev/gems/librarian-0.1.2/lib/librarian/resolver.rb:23:in `resolve'
        from ~/.rvm/gems/ruby-2.0.0-p481@chef-dev/gems/librarian-0.1.2/lib/librarian/action/resolve.rb:26:in `run'
        from ~/.rvm/gems/ruby-2.0.0-p481@chef-dev/gems/librarian-0.1.2/lib/librarian/cli.rb:169:in `resolve!'
        from ~/.rvm/gems/ruby-2.0.0-p481@chef-dev/gems/librarian-0.1.2/lib/librarian/cli.rb:113:in `update'
        from ~/.rvm/gems/ruby-2.0.0-p481@chef-dev/gems/thor-0.18.1/lib/thor/command.rb:27:in `run'
        from ~/.rvm/gems/ruby-2.0.0-p481@chef-dev/gems/thor-0.18.1/lib/thor/invocation.rb:120:in `invoke_command'
        from ~/.rvm/gems/ruby-2.0.0-p481@chef-dev/gems/thor-0.18.1/lib/thor.rb:363:in `dispatch'
        from ~/.rvm/gems/ruby-2.0.0-p481@chef-dev/gems/thor-0.18.1/lib/thor/base.rb:439:in `start'
        from ~/.rvm/gems/ruby-2.0.0-p481@chef-dev/gems/librarian-0.1.2/lib/librarian/cli.rb:26:in `block (2 levels) in bin!'
        from ~/.rvm/gems/ruby-2.0.0-p481@chef-dev/gems/librarian-0.1.2/lib/librarian/cli.rb:31:in `returning_status'
        from ~/.rvm/gems/ruby-2.0.0-p481@chef-dev/gems/librarian-0.1.2/lib/librarian/cli.rb:26:in `block in bin!'
        from ~/.rvm/gems/ruby-2.0.0-p481@chef-dev/gems/librarian-0.1.2/lib/librarian/cli.rb:47:in `with_environment'
        from ~/.rvm/gems/ruby-2.0.0-p481@chef-dev/gems/librarian-0.1.2/lib/librarian/cli.rb:26:in `bin!'
        from ~/.rvm/gems/ruby-2.0.0-p481@chef-dev/gems/librarian-chef-0.0.4/bin/librarian-chef:7:in `<top (required)>'
        from ~/.rvm/gems/ruby-2.0.0-p481@chef-dev/bin/librarian-chef:23:in `load'
        from ~/.rvm/gems/ruby-2.0.0-p481@chef-dev/bin/librarian-chef:23:in `<main>'
        from ~/.rvm/gems/ruby-2.0.0-p481@chef-dev/bin/ruby_executable_hooks:15:in `eval'
        from ~/.rvm/gems/ruby-2.0.0-p481@chef-dev/bin/ruby_executable_hooks:15:in `<main>'
```
